### PR TITLE
Updates menu labels 

### DIFF
--- a/menus/cargo-test-runner.cson
+++ b/menus/cargo-test-runner.cson
@@ -2,10 +2,10 @@
 'context-menu':
   'atom-text-editor, .overlayer': [
     {
-      'label': 'cargo-test-runner'
+      'label': 'Cargo Test Runner'
       'submenu': [
         { label: 'Run Cargo tests', command: 'cargo-test-runner:run' }
-        { label: 'Re-run last Cargo tests', command: 'cargo-test-runner:run-previous' }
+        { label: 'Rerun Last Cargo Tests', command: 'cargo-test-runner:run-previous' }
       ]
     }
   ]
@@ -14,10 +14,10 @@
   {
     'label': 'Packages'
     'submenu': [
-      'label': 'cargo-test-runner'
+      'label': 'Cargo Test Runner'
       'submenu': [
-        { 'label': 'Run tests', 'command': 'cargo-test-runner:run' },
-        { 'label': 'Re-run last tests', 'command': 'cargo-test-runner:run-previous'}
+        { 'label': 'Run Tests', 'command': 'cargo-test-runner:run' },
+        { 'label': 'Rerun Last Tests', 'command': 'cargo-test-runner:run-previous'}
       ]
     ]
   }

--- a/menus/cargo-test-runner.cson
+++ b/menus/cargo-test-runner.cson
@@ -4,7 +4,7 @@
     {
       'label': 'Cargo Test Runner'
       'submenu': [
-        { label: 'Run Cargo tests', command: 'cargo-test-runner:run' }
+        { label: 'Run Cargo Tests', command: 'cargo-test-runner:run' }
         { label: 'Rerun Last Cargo Tests', command: 'cargo-test-runner:run-previous' }
       ]
     }


### PR DESCRIPTION
Packages in Atom tend to set labels so as each word is capitalized. Really minor change so that it follows this style.
