### PR TITLE
remove file name from cargo flags

### DIFF
--- a/lib/cargo.coffee
+++ b/lib/cargo.coffee
@@ -24,7 +24,7 @@ module.exports = class CargoWrapper extends events.EventEmitter
 
   run: ->
 
-    flags = ['test', getFileWithoutExtension(@context.test)]
+    flags = ['test']
 
     if @options
       Array::push.apply flags, @options.split ' '


### PR DESCRIPTION
Hi nguyenchr,

I am just evaluating atom as my new rust IDE.
But I really want to be able to run tests from it.

This small change fixed it for me:

if the cargo flags are just 'test' it works fine

with kind regards

ferkulat
